### PR TITLE
Fixed dependency version of org.opensourcebim.pluginbase to 2.0.0

### DIFF
--- a/DemoPlugins/pom.xml
+++ b/DemoPlugins/pom.xml
@@ -172,12 +172,12 @@
 		<dependency>
 			<groupId>org.opensourcebim</groupId>
 			<artifactId>pluginbase</artifactId>
-			<version>1.5.46-SNAPSHOT</version>
+			<version>2.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opensourcebim</groupId>
 			<artifactId>shared</artifactId>
-			<version>1.5.46-SNAPSHOT</version>
+			<version>2.0.0</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>


### PR DESCRIPTION
Fixed dependency version of org.opensourcebim.shared to 2.0.0
